### PR TITLE
Fix exception matching bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,12 +1,20 @@
 # Changes
 
+##### 1.1.2 - 2015-06-16
+
+__1.1.2 will be the last release that works with JDK 6! With Maven having moved to JDK 7, there
+is no reason anymore for plugins to stick to an old JDK version.__
+
+* Fix a bug where an exception is ignored if more conflicts are listed in the exception than
+actually conflicting jars are present.
+
 ##### 1.1.1 - 2015-01-18
 
 * Issue #9. Ignore project references that are not on the dependency list. Thanks @victornoel.
 * Add maven properties for all simple (boolean, int, string) configuration settings.
 * Ning Issue #44: Allow duplicate checking against elements from the boot classpath
-  (this includes rt.jar). 
-* Ning Issue #19: Report a defined message if plugin skips execution. 
+  (this includes rt.jar).
+* Ning Issue #19: Report a defined message if plugin skips execution.
 
 ##### 1.1.0 - 2014-12-27
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-standard-oss</artifactId>
-        <version>8</version>
+        <version>11</version>
     </parent>
 
     <groupId>org.basepom.maven</groupId>

--- a/src/it/test-class-conflict-class-exclude-non-match/invoker.properties
+++ b/src/it/test-class-conflict-class-exclude-non-match/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean verify
+invoker.buildResult = failure

--- a/src/it/test-class-conflict-class-exclude-non-match/pom.xml
+++ b/src/it/test-class-conflict-class-exclude-non-match/pom.xml
@@ -1,0 +1,68 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>@project.groupId@.@project.artifactId@</groupId>
+        <artifactId>basepom</artifactId>
+        <version>1.0.under-test</version>
+    </parent>
+
+    <artifactId>test-class-conflict-class-exclude-non-match</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-class-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-diff-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <exceptions>
+                        <exception>
+                            <conflictingDependencies>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-class-jar</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-diff-jar</artifactId>
+                                </dependency>
+                            </conflictingDependencies>
+                            <classes>
+                                <class>diff.NotDemo</class>
+                            </classes>
+                        </exception>
+                    </exceptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test-class-conflict-class-exclude-non-match/verify.groovy
+++ b/src/it/test-class-conflict-class-exclude-non-match/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.basepom.mojo.duplicatefinder.groovy.ITools.*
+
+def result = loadTestXml(basedir)
+
+overallState(CONFLICT_DIFF, 1, FAILED, result)
+checkConflictResult("diff.Demo", TYPE_CLASS, CONFLICT_DIFF, NOT_EXCEPTED, PRINTED, FAILED, findConflictResult(result, FIRST_CLASS_JAR, FIRST_DIFF_JAR))
+
+return true

--- a/src/it/test-class-conflict-class-exclude-three-ways/invoker.properties
+++ b/src/it/test-class-conflict-class-exclude-three-ways/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean verify
+invoker.buildResult = success

--- a/src/it/test-class-conflict-class-exclude-three-ways/pom.xml
+++ b/src/it/test-class-conflict-class-exclude-three-ways/pom.xml
@@ -1,0 +1,72 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>@project.groupId@.@project.artifactId@</groupId>
+        <artifactId>basepom</artifactId>
+        <version>1.0.under-test</version>
+    </parent>
+
+    <artifactId>test-class-conflict-class-exclude-three-ways</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-class-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-diff-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <exceptions>
+                        <exception>
+                            <conflictingDependencies>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-class-jar</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>second-class-jar</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-diff-jar</artifactId>
+                                </dependency>
+                            </conflictingDependencies>
+                            <classes>
+                                <class>diff.Demo</class>
+                            </classes>
+                        </exception>
+                    </exceptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test-class-conflict-class-exclude-three-ways/verify.groovy
+++ b/src/it/test-class-conflict-class-exclude-three-ways/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.basepom.mojo.duplicatefinder.groovy.ITools.*
+
+def result = loadTestXml(basedir)
+
+overallState(NO_CONFLICT, 1, NOT_FAILED, result)
+checkConflictResult("diff.Demo", TYPE_CLASS, CONFLICT_DIFF, EXCEPTED, NOT_PRINTED, NOT_FAILED, findConflictResult(result, FIRST_CLASS_JAR, FIRST_DIFF_JAR))
+
+return true

--- a/src/it/test-class-conflict-class-exclude/invoker.properties
+++ b/src/it/test-class-conflict-class-exclude/invoker.properties
@@ -1,0 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals=clean verify
+invoker.buildResult = success

--- a/src/it/test-class-conflict-class-exclude/pom.xml
+++ b/src/it/test-class-conflict-class-exclude/pom.xml
@@ -1,0 +1,68 @@
+<!--
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>@project.groupId@.@project.artifactId@</groupId>
+        <artifactId>basepom</artifactId>
+        <version>1.0.under-test</version>
+    </parent>
+
+    <artifactId>test-class-conflict-class-exclude</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-class-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+        <dependency>
+            <groupId>testjar</groupId>
+            <artifactId>first-diff-jar</artifactId>
+            <version>1.0.under-test</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <exceptions>
+                        <exception>
+                            <conflictingDependencies>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-class-jar</artifactId>
+                                </dependency>
+                                <dependency>
+                                    <groupId>testjar</groupId>
+                                    <artifactId>first-diff-jar</artifactId>
+                                </dependency>
+                            </conflictingDependencies>
+                            <classes>
+                                <class>diff.Demo</class>
+                            </classes>
+                        </exception>
+                    </exceptions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test-class-conflict-class-exclude/verify.groovy
+++ b/src/it/test-class-conflict-class-exclude/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static org.basepom.mojo.duplicatefinder.groovy.ITools.*
+
+def result = loadTestXml(basedir)
+
+overallState(NO_CONFLICT, 1, NOT_FAILED, result)
+checkConflictResult("diff.Demo", TYPE_CLASS, CONFLICT_DIFF, EXCEPTED, NOT_PRINTED, NOT_FAILED, findConflictResult(result, FIRST_CLASS_JAR, FIRST_DIFF_JAR))
+
+return true

--- a/src/main/java/org/basepom/mojo/duplicatefinder/ConflictingDependency.java
+++ b/src/main/java/org/basepom/mojo/duplicatefinder/ConflictingDependency.java
@@ -164,17 +164,24 @@ public class ConflictingDependency
             return false;
         }
 
-        if (artifacts.size() != conflictingDependencies.size()) {
+        // An exception can contain more than the actually matching
+        // artifacts. In that case, we will check this exception if at least
+        // the number of artifacts are present.
+        if (artifacts.size() > conflictingDependencies.size()) {
             return false;
         }
 
-        int numMatches = conflictingDependencies.size();
+        // Every artifact must be matched.
+        int numMatches = artifacts.size();
 
         for (final Artifact artifact : artifacts) {
             for (final MavenCoordinates conflictingDependency : conflictingDependencies) {
                 if (conflictingDependency.matches(artifact)) {
                     if (--numMatches == 0) {
                         return true;
+                    }
+                    else {
+                        break; // for (final MavenCoordinates...
                     }
                 }
             }


### PR DESCRIPTION
This fixes a bug where an exception is ignored if more conflicts are
listed in the exception than actually conflicting jars are present.