### PR TITLE
Switch to a toolchain based build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: java
+
 jdk:
   - oraclejdk7
   - oraclejdk8
+
+sudo: false
+
+before_install:
+    - cp src/build/travis-toolchains.xml ~/.m2/toolchains.xml
+
 install: mvn -DskipTests=true -Dbasepom.check.skip-all=true -Dbasepom.it.skip=true -B install
 script: mvn -B verify
+
 addons:
   artifacts:
     debug: true

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
     <properties>
         <dep.basepom-policy.version>4</dep.basepom-policy.version>
 
-        <project.jdk7.home>${env.JAVA7_HOME}</project.jdk7.home>
         <project.build.targetJdk>1.7</project.build.targetJdk>
 
         <dep.maven-api.version>3.0</dep.maven-api.version>
@@ -237,6 +236,20 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>1.1</version>
+                    <configuration>
+                        <toolchains>
+                            <jdk>
+                                <version>${project.build.targetJdk}</version>
+                                <vendor>sun</vendor>
+                            </jdk>
+                        </toolchains>
+                    </configuration>
+                </plugin>
+
+                <plugin>
                     <groupId>org.codehaus.plexus</groupId>
                     <artifactId>plexus-component-metadata</artifactId>
                     <version>${dep.plexus.version}</version>
@@ -315,6 +328,17 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
@@ -411,9 +435,6 @@
                     <name>env.TRAVIS</name>
                 </property>
             </activation>
-            <properties>
-                <project.jdk7.home>${env.JAVA_HOME}</project.jdk7.home>
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -426,60 +447,7 @@
                             </pomExcludes>
                         </configuration>
                     </plugin>
-                    <!-- have travis build the javadoc jar to check whether it builds ok -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>doclint</id>
-            <activation>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <configuration>
-                                <additionalparam>-Xdoclint:none</additionalparam>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>cross-compile</id>
-            <activation>
-                <jdk>(1.7,]</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <compilerArguments children.combine="append">
-                                    <bootclasspath>${project.jdk7.home}/jre/lib/rt.jar:${project.jdk7.home}/jre/lib/jce.jar:${project.jdk7.home}/../classes/classes.jar</bootclasspath>
-                                </compilerArguments>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
     </profiles>

--- a/src/build/travis-toolchains.xml
+++ b/src/build/travis-toolchains.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+~   Copyright (C) 2004 - 2014 Brian McCallister
+~
+~   Licensed under the Apache License, Version 2.0 (the "License");
+~   you may not use this file except in compliance with the License.
+~   You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~   Unless required by applicable law or agreed to in writing, software
+~   distributed under the License is distributed on an "AS IS" BASIS,
+~   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~   See the License for the specific language governing permissions and
+~   limitations under the License.
+-->
+<toolchains>
+    <!-- JDK toolchains -->
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.7</version>
+            <vendor>sun</vendor>
+        </provides>
+        <configuration>
+            <!-- Location of a JDK7 in the Travis build environment -->
+            <jdkHome>/usr/lib/jvm/java-7-oracle</jdkHome>
+        </configuration>
+    </toolchain>
+</toolchains>


### PR DESCRIPTION
This should fix #18, however now you must create a ~/.m2/toolchains.xml
file, as described on
https://maven.apache.org/guides/mini/guide-using-toolchains.html