### PR TITLE
Ignore all module-info classes

### DIFF
--- a/src/main/java/org/basepom/mojo/duplicatefinder/classpath/ClasspathDescriptor.java
+++ b/src/main/java/org/basepom/mojo/duplicatefinder/classpath/ClasspathDescriptor.java
@@ -75,7 +75,7 @@ public class ClasspathDescriptor
     private static final MatchPatternPredicate DEFAULT_IGNORED_CLASS_PREDICATE = new MatchPatternPredicate(Arrays.asList(
         // this regex matches inner classes
         ".*\\$.*",
-        "module-info"));
+        ".*module-info$"));
 
     private static final MatchPatternPredicate DEFAULT_IGNORED_LOCAL_DIRECTORIES = new MatchPatternPredicate(Arrays.asList(
         "^.git$",


### PR DESCRIPTION
module-info classes can be stored in subdirectories, which makes them
appear with packages in the duplicate analysis. An example of this is
Byte Buddy 1.9.3, which ships META-INF/versions/9/module-info.class in
both byte-buddy and byte-buddy-agent.

This patch ignores module-info classes anywhere. This fixes #33.

Signed-off-by: Stephen Kitt <skitt@redhat.com>