### PR TITLE
Rework the class exclusion rules

### DIFF
--- a/src/it/setup-class-jars/first-class-jar/src/main/java/diff/package-info.java
+++ b/src/it/setup-class-jars/first-class-jar/src/main/java/diff/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Deprecated
+package diff;
+
+/**
+ * Package docs.
+ */

--- a/src/it/setup-class-jars/first-diff-jar/src/main/java/diff/package-info.java
+++ b/src/it/setup-class-jars/first-diff-jar/src/main/java/diff/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Deprecated
+package diff;
+
+/**
+ * Package docs.
+ */

--- a/src/it/setup-class-jars/second-class-jar/src/main/java/demo/package-info.java
+++ b/src/it/setup-class-jars/second-class-jar/src/main/java/demo/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@Deprecated
+package demo;
+
+/**
+ * Package docs.
+ */

--- a/src/main/java/org/basepom/mojo/duplicatefinder/classpath/ClasspathDescriptor.java
+++ b/src/main/java/org/basepom/mojo/duplicatefinder/classpath/ClasspathDescriptor.java
@@ -76,10 +76,13 @@ public class ClasspathDescriptor
         ".*package\\.html$",
         ".*overview\\.html$"));
 
-    private static final MatchPatternPredicate DEFAULT_IGNORED_CLASS_PREDICATE = new MatchPatternPredicate(Arrays.asList(
-        // this regex matches inner classes
-        ".*\\$.*",
-        "module-info"));
+    @VisibleForTesting
+    static final MatchPatternPredicate DEFAULT_IGNORED_CLASS_PREDICATE = new MatchPatternPredicate(Arrays.asList(
+
+        "^(.*\\.)?.*\\$.*$",      // matches inner classes in any package
+        "^(.*\\.)?package-info$", // matches package-info in any package
+        "^(.*\\.)?module-info$"   // matches module-info in any package
+        ));
 
     private static final MatchPatternPredicate DEFAULT_IGNORED_LOCAL_DIRECTORIES = new MatchPatternPredicate(Arrays.asList(
         "^.git$",
@@ -396,7 +399,9 @@ public class ClasspathDescriptor
         }
 
         String className = Files.getNameWithoutExtension(classFileName);
-        if (!(SourceVersion.isIdentifier(className) || "module-info".equals(className))) {
+        if (!(SourceVersion.isIdentifier(className)
+              || "module-info".equals(className)
+              || "package-info".equals(className))) {
             LOG.debug("Ignoring %s, %s is not a valid class identifier", fullClassPath, className);
             return Optional.empty();
         }

--- a/src/test/java/org/basepom/mojo/duplicatefinder/classpath/TestClasspathDescriptor.java
+++ b/src/test/java/org/basepom/mojo/duplicatefinder/classpath/TestClasspathDescriptor.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 public class TestClasspathDescriptor
 {
     @Test
-    public void testValidPackageNames()
+    public void testValidIdentifierNames()
     {
         String[] validNames = {
                 "_.class",
@@ -32,6 +32,8 @@ public class TestClasspathDescriptor
                 "test.class",
                 "__auto_generated/from/some/tool.class",
                 "some/inner$thing.class",
+                "some/package/package-info.class", // package info in sub package
+                "package-info.class", // package info in root package
                 "some/package/module-info.class", // module info in sub package
                 "module-info.class" // module info in root package
         };
@@ -43,7 +45,7 @@ public class TestClasspathDescriptor
     }
 
     @Test
-    public void testInvalidPackageNames()
+    public void testInvalidIdentifierNames()
     {
         String[] invalidNames = {
                 null, // null value
@@ -55,6 +57,7 @@ public class TestClasspathDescriptor
                 "2.0/foo.class", // package name invalid
                 "foo/bar/baz-blo/tst.class", // package name is invalid
                 "META-INF/versions/9/foo/module-info.class", // module info in version sub package
+                "META-INF/versions/9/foo/package-info.class" // package info in version sub package
         };
 
 
@@ -63,4 +66,22 @@ public class TestClasspathDescriptor
             assertFalse("Failure for '" + test + "'", result.isPresent());
         }
     }
+
+    @Test
+    public void testMatchDefaultClassnames()
+    {
+        String[] validClassNames = {
+                "foo$bar",
+                "hello.foo$bar",
+                "package-info",
+                "module-info",
+                "demo.package-info",
+                "foo.module-info"
+        };
+
+        for (String test : validClassNames) {
+            assertTrue("Failure for '" + test + "'", ClasspathDescriptor.DEFAULT_IGNORED_CLASS_PREDICATE.apply(test));
+        }
+    }
+
 }


### PR DESCRIPTION
Clarify how class exclusions work, change the regexps to exclude
elements from the class path (turns out that the inner class check only
worked by accident). Add a test for the class elements.

Add package-info files to the integration test jars, ensure that all
tests still pass.